### PR TITLE
Add simple HTML gallery app

### DIFF
--- a/docs/gallery.html
+++ b/docs/gallery.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Photothèque</title>
   <!-- On importe la feuille de styles compilée (version 3.0 de gallery.css) -->
   <link rel="stylesheet" href="stylesheets/gallery.css">

--- a/docs/newapp/app.js
+++ b/docs/newapp/app.js
@@ -1,0 +1,14 @@
+fetch('photos.json')
+  .then(r => r.json())
+  .then(photos => {
+    const gallery = document.getElementById('gallery');
+    photos.forEach(p => {
+      const img = document.createElement('img');
+      img.src = p.file;
+      img.alt = p.title || '';
+      gallery.appendChild(img);
+    });
+  })
+  .catch(err => {
+    console.error('Erreur lors du chargement des photos:', err);
+  });

--- a/docs/newapp/index.html
+++ b/docs/newapp/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Nouvelle Galerie Photo</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Nouvelle Galerie Photo</h1>
+  <div id="gallery" class="gallery"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/newapp/photos.json
+++ b/docs/newapp/photos.json
@@ -1,0 +1,5 @@
+[
+  {"file": "../thumbnails/1499866339980.jpg", "title": "Photo 1"},
+  {"file": "../thumbnails/1499866340000.jpg", "title": "Photo 2"},
+  {"file": "../thumbnails/1499866340013.jpg", "title": "Photo 3"}
+]

--- a/docs/newapp/style.css
+++ b/docs/newapp/style.css
@@ -1,0 +1,18 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.gallery img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add a small HTML photo gallery under `docs/newapp`
- include dataset, styles and JS loader
- make the existing gallery page responsive by adding a viewport meta tag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684927301f94832ca9f5175e88ab4f03